### PR TITLE
Adds duration

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -28,6 +28,7 @@ jobs:
           pip install -r requirements.txt
           pip install flake8
           pip install yamllint
+          sudo apt-get update && sudo apt-get install ffmpeg
 
       - name: Lint with flake8
         run: |
@@ -36,6 +37,7 @@ jobs:
 
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
 
       - name: Ensure example file passes YAmllint
         run: |

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This tool was written for my podcast [Nerding Out with Viktor](https://blog.vikt
 
 - Python 3.8 or higher
 - pip (Python package installer)
+- ffmpeg
 
 ### Setup
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 PyYAML==6.0.1
 requests==2.31.0
 Markdown==3.5.1
+sh==2.0.6


### PR DESCRIPTION
Uses `ffprobe` (via `sh`) to get the duration of remote assets. Should work for both video and audio without having to download the full file.