### PR TITLE
Correctly escape CDATA in XML

### DIFF
--- a/rss_generator.py
+++ b/rss_generator.py
@@ -63,6 +63,23 @@ class MockResponse:
         }
 
 
+def _escape_cdata(text):
+    try:
+        if "&" in text:
+            text = text.replace("&", "&amp;")
+        # Don't excape lt and gt in CDATA
+        # if "<" in text:
+        # text = text.replace("<", "&lt;")
+        # if ">" in text:
+        # text = text.replace(">", "&gt;")
+        return text
+    except TypeError:
+        raise TypeError(
+            "cannot serialize %r (type %s)" % (text, type(text).__name__)
+        )
+ET._escape_cdata = _escape_cdata
+
+
 def read_podcast_config(yaml_file_path):
     with open(yaml_file_path, "r", encoding="utf-8") as file:
         return yaml.safe_load(file)


### PR DESCRIPTION
Thank you so much for your script. It helped me a lot while producing my private podcast.

While testing it came to my attention that the produced XML, while valid, does not produce correct CDATA excapes. Example with unpatched version:
`<description>&lt;![CDATA[&lt;p&gt;My Description&lt;/p&gt;]]&gt;</description>`

This can be fixed by simple patch the element tree's __escape_cdata_ method. With attached patch the resulting XML looks like this:
`<description><![CDATA[<p>My Description</p>]]></description>`